### PR TITLE
[BUGFIX] Add timeout to onmousedown attribute

### DIFF
--- a/Classes/Plugin/PluginController.php
+++ b/Classes/Plugin/PluginController.php
@@ -494,7 +494,7 @@ class PluginController extends AbstractPlugin
         $content = $this->conf['html_before'];
         $additionalAttributes = array();
         if ($linkTarget === '_blank') {
-            $additionalAttributes[] = 'onmousedown="location.reload();"';
+            $additionalAttributes[] = 'onmousedown="setTimeout(function () {location.reload()},300);"';
         }
         $content .= '<a ' . implode(' ', $additionalAttributes) . ' href="' . htmlspecialchars($appLogonUrl) . '" target="' . htmlspecialchars($linkTarget) . '">' . htmlspecialchars($linkText) . '</a>';
         $content .= $this->conf['html_after'];


### PR DESCRIPTION
Add timeout to onmousedown attribute of a link with target=_blank
Links, that have target=_blank, do not open in IE 11 and IE Edge.

Resolves: #1